### PR TITLE
Quote string literals to calm YAML

### DIFF
--- a/jasmine.yml
+++ b/jasmine.yml
@@ -1,11 +1,11 @@
-src_dir: .
+src_dir: '.'
 
 # all files, including specs, are included as src_files
 src_files:
-    - **/*.js
-    - ../helpers/**/*.js
-    - helpers/**/*.js
+    - '**/*.js'
+    - '../helpers/**/*.js'
+    - 'helpers/**/*.js'
 
 # in order to remove duplicates, specify a nonexistent dir for specs
-spec_dir: nada
+spec_dir: 'nada'
 


### PR DESCRIPTION
It's not clear to me from YAML's spec that this should be necessary, but `rake jasmine` failed with the following in the previous version:

```
telemachus learn_javascript [master= 43a0d4a]$ rake jasmine
your tests are here:
  http://localhost:8888/
rake aborted!
(<unknown>): couldn't parse YAML at line 4 column 7

Tasks: TOP => jasmine => jasmine:server
(See full trace by running task with --trace)
```

Line 4, column 7 (by YAML's count) is line 5 of the file: this string - `**/*.js`. Only that one string seems to require quotes, but I quoted all the strings for the sake of consistency.

Other information, in case it's useful:
- ruby 1.9.3p125 (2012-02-16 revision 34643) [x86_64-darwin11.3.0]
- YAML 1.2.2
- rake, version 0.9.2.2
- jasmine (1.1.2), jasmine-core (1.1.0)

Thanks.
